### PR TITLE
Remove some docs and the user capability grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Chassis extension installs and activates Query Monitor using Puppet and WP-
 
 ## Integrating Query Monitor with IDEs
 
-To integrate Query Monitor with your IDE you will need to add some filters to your code. e.g.
+To integrate Query Monitor with your IDE you will need to add a filters to your code to map the remote directory in Chassis to your local directory, e.g.
 ```
 <?php
 $data = json_decode( file_get_contents( '/etc/chassis-constants' ) );
@@ -21,13 +21,5 @@ $data = json_decode( file_get_contents( '/etc/chassis-constants' ) );
 add_filter( 'qm/output/file_path_map', function ( $map ) use ( $data ) {
 	$map = array_merge( $map, (array) $data->synced_folders );
 	return $map;
-} );
-# For Visual Studio Code
-add_filter( 'qm/output/file_link_format', function ( $format ) {
-	return 'vscode://file/%f:%l';
-} );
-# For PhpStorm
-add_filter( 'qm/output/file_link_format', function ( $format ) {
-	return 'idea://file/%f:%l';
 } );
 ```

--- a/modules/query_monitor/manifests/init.pp
+++ b/modules/query_monitor/manifests/init.pp
@@ -42,10 +42,4 @@ class query_monitor (
 		target  => "${content_location}/plugins/query-monitor/wp-content/db.php",
 		require => Chassis::Wp[ $config['hosts'][0] ],
 	}
-
-	exec { "/usr/bin/wp cap add 'administrator' 'view_query_monitor'":
-		user    => 'www-data',
-		require => [ Chassis::Wp[ $config['hosts'][0] ], Wp::Plugin['query-monitor'] ],
-		cwd     => "${base_location}/wp",
-	}
 }


### PR DESCRIPTION
The `file_link_format` filter isn't needed any more since there's now a UI in QM's settings panel to configure this.

The cap granting hasn't been needed for a long while.